### PR TITLE
change README to match library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ FetchContent_MakeAvailable(ftxui)
 FetchContent_MakeAvailable(ftxui-grid-input)
 add_executable(my-app src/main.cpp)
 target_link_libraries(my-app
-  PRIVATE ftxui-grid-input
+  PRIVATE ftxui-grid-container
 )
 ```

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ FetchContent_Declare(ftxui
   GIT_TAG v5.0.0
 )
 
-FetchContent_Declare(ftxui-grid-input
+FetchContent_Declare(ftxui-grid-container
   GIT_REPOSITORY https://github.com/mingsheng13/grid-container-ftxui
   GIT_TAG master
 )
 
 FetchContent_MakeAvailable(ftxui)
-FetchContent_MakeAvailable(ftxui-grid-input)
+FetchContent_MakeAvailable(ftxui-grid-container)
 add_executable(my-app src/main.cpp)
 target_link_libraries(my-app
   PRIVATE ftxui-grid-container


### PR DESCRIPTION
First of all, nice library! I love how intuitive this is :)
I want to be able to use through CMake but I noticed the library generation in your internal CMakeLists (ftxui-grid-container) does not match what the README suggests when trying to use the library. This PR just suggests to keep things consistent. Don't know what you prefer. Either ways, thanks! 😄 